### PR TITLE
Update Fusabi dependencies to 0.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "bevy-fusabi"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bevy",
@@ -1312,20 +1312,21 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fusabi-frontend"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c2e9c1ad85e4e711060f57249d90d5b7a8695332eb85dcf4a368f833cd86d3"
+checksum = "0b3f1fbcd3597491f2a491447952ef967bb00bb21ba463b8dba8616522a9148c"
 dependencies = [
  "fusabi-vm",
 ]
 
 [[package]]
 name = "fusabi-vm"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6189bf3121fb4a7b22c18896aa6876f909e81f7375484fefec90d931d7d37387"
+checksum = "3220fb0719eaadf36f5913999e16def5f73a022ae4dfae867f58cfced7594530"
 dependencies = [
  "bincode",
+ "lazy_static",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-fusabi"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Aaron Brewbaker <brewbaker.aaron@gmail.com>"]
 description = "Bevy integration for the Fusabi scripting language"
@@ -18,8 +18,8 @@ rust-version = "1.75"
 bevy = { version = "0.15", default-features = false, features = ["bevy_asset"] }
 
 # Fusabi Runtime & Compiler
-fusabi-vm = { version = "0.17.0", features = ["serde"] }
-fusabi-frontend = "0.17.0"
+fusabi-vm = { version = "0.21.0", features = ["serde"] }
+fusabi-frontend = "0.21.0"
 
 # Utilities
 thiserror = "1.0"

--- a/examples/load_script.rs
+++ b/examples/load_script.rs
@@ -12,7 +12,7 @@ fn main() {
 }
 
 #[derive(Resource)]
-struct ScriptHandle(Handle<FusabiScript>);
+struct ScriptHandle(#[allow(dead_code)] Handle<FusabiScript>);
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let handle = asset_server.load("hello.fsx");
@@ -25,22 +25,19 @@ fn check_asset(
     scripts: Res<Assets<FusabiScript>>,
 ) {
     for event in events.read() {
-        match event {
-            AssetEvent::LoadedWithDependencies { id } => {
-                let script = scripts.get(*id).unwrap();
-                println!("Script loaded successfully: {}", script.name);
-                println!("Bytecode size: {} bytes", script.bytecode.len());
+        if let AssetEvent::LoadedWithDependencies { id } = event {
+            let script = scripts.get(*id).unwrap();
+            println!("Script loaded successfully: {}", script.name);
+            println!("Bytecode size: {} bytes", script.bytecode.len());
 
-                // Verify we can deserialize it
-                match script.to_chunk() {
-                    Ok(chunk) => println!(
-                        "Deserialized chunk successfully. Opcode count: {}",
-                        chunk.instructions.len()
-                    ),
-                    Err(e) => println!("Failed to deserialize chunk: {}", e),
-                }
+            // Verify we can deserialize it
+            match script.to_chunk() {
+                Ok(chunk) => println!(
+                    "Deserialized chunk successfully. Opcode count: {}",
+                    chunk.instructions.len()
+                ),
+                Err(e) => println!("Failed to deserialize chunk: {}", e),
             }
-            _ => {}
         }
     }
 }


### PR DESCRIPTION
## Summary
- Updated `fusabi-vm` from 0.17.0 to 0.21.0
- Updated `fusabi-frontend` from 0.17.0 to 0.21.0
- Bumped package version from 0.1.4 to 0.2.0

## Test Plan
- [x] `cargo check` passes successfully
- [x] `cargo test` passes (no test failures)
- [x] All examples compile without errors
- [x] No API changes required - existing code is fully compatible

## Notes
The Fusabi dependency updates are backward compatible with the existing API usage in bevy-fusabi. All functionality works without modification.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)